### PR TITLE
fix usbInstall call error

### DIFF
--- a/app/src/main/java/com/oosl/colorostool/plugin/HookAndroid.java
+++ b/app/src/main/java/com/oosl/colorostool/plugin/HookAndroid.java
@@ -22,7 +22,7 @@ public class HookAndroid extends HookBase {
         super.hook(lpparam);
         ClassLoader classLoader = lpparam.classLoader;
         if (ColorToolPrefs.getPrefs("usb_install", false)) {
-            removeForceApp(classLoader);
+            usbInstall(classLoader);
         }
         if (ColorToolPrefs.getPrefs("remove_oppo_default_app", false)) {
             removeForceApp(classLoader);


### PR DESCRIPTION
Which cause removal of usb installation confirmation has no effect.